### PR TITLE
don't translate if source is square

### DIFF
--- a/transformations/src/main/java/jp/wasabeef/picasso/transformations/CropCircleTransformation.java
+++ b/transformations/src/main/java/jp/wasabeef/picasso/transformations/CropCircleTransformation.java
@@ -39,9 +39,11 @@ public class CropCircleTransformation implements Transformation {
         Paint paint = new Paint();
         BitmapShader shader = new BitmapShader(source, BitmapShader.TileMode.CLAMP,
                 BitmapShader.TileMode.CLAMP);
-        Matrix matrix = new Matrix();
-        matrix.setTranslate(-width, -height);
-        shader.setLocalMatrix(matrix);
+        if (width != 0 || height != 0) { // source isn't square, move viewport to centre
+            Matrix matrix = new Matrix();
+            matrix.setTranslate(-width, -height);
+            shader.setLocalMatrix(matrix);
+        }
         paint.setShader(shader);
         paint.setAntiAlias(true);
 


### PR DESCRIPTION
Just a small performance enhancement so that we don't create a `Matrix` when no translation will be done.