### PR TITLE
Fix bug in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ repositories {
 }
 
 dependencies {
-    compile 'jp.wasabeef:picasso-transformations:1.3.0.'
+    compile 'jp.wasabeef:picasso-transformations:1.3.0'
     // If you want to use the GPU Filters
     compile 'jp.co.cyberagent.android.gpuimage:gpuimage-library:1.3.0'
 }


### PR DESCRIPTION
The Gradle dependency line included an extra `.` at the end, which would make the dependency fail if people would just copy-paste it.